### PR TITLE
Molten Coin now works with Ignition Tank

### DIFF
--- a/SS2-Project/Assets/Starstorm2/Modules/Pickups/Items/Tier1/MoltenCoin.cs
+++ b/SS2-Project/Assets/Starstorm2/Modules/Pickups/Items/Tier1/MoltenCoin.cs
@@ -30,6 +30,7 @@ namespace Moonstorm.Starstorm2.Items
                             damageMultiplier = 1f + (stack * 1f)
                             //If you're trying to configure this and are so desperate you've come here, I don't have a damn clue.
                         };
+                        StrengthenBurnUtils.CheckDotForUpgrade(report.attackerBody.inventory, ref dotInfo);
                         DotController.InflictDot(ref dotInfo);
                         body.master.GiveMoney((uint)(stack * (Run.instance.stageClearCount + (1 * 1f))));
                         MSUtil.PlayNetworkedSFX("MoltenCoin", report.victim.gameObject.transform.position);


### PR DESCRIPTION
it didn't and now it does
edit: adds a CheckDotForUpgrade check to Molten Coin's DoT application.