### PR TITLE
Update to 0.3.39

### DIFF
--- a/SS2-Project/Assets/Starstorm2/AssetStorm/EntityStateConfigurations/Executioner/EntityStates.Executioner.AxeSlam.asset
+++ b/SS2-Project/Assets/Starstorm2/AssetStorm/EntityStateConfigurations/Executioner/EntityStates.Executioner.AxeSlam.asset
@@ -35,7 +35,7 @@ MonoBehaviour:
         objectValue: {fileID: 0}
     - fieldName: upwardDuration
       fieldValue:
-        stringValue: 0.9
+        stringValue: 0.7
         objectValue: {fileID: 0}
     - fieldName: slamRadius
       fieldValue:

--- a/SS2-Project/Assets/Starstorm2/AssetStorm/Prefabs/Effects/EventEffects/BlizzardEffect.prefab
+++ b/SS2-Project/Assets/Starstorm2/AssetStorm/Prefabs/Effects/EventEffects/BlizzardEffect.prefab
@@ -9552,7 +9552,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2694481602023696533}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 383b25b8766c1ee429cfb2a366180890, type: 3}
   m_Name: 
@@ -18903,11 +18903,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Materials.Array.size
       value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8543651029721732279, guid: 935e31f336cdea04195b272ac3f2f648,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8543651029721732279, guid: 935e31f336cdea04195b272ac3f2f648,
         type: 3}

--- a/SS2-Project/Assets/Starstorm2/Modules/Characters/Survivors/Nemmando.cs
+++ b/SS2-Project/Assets/Starstorm2/Modules/Characters/Survivors/Nemmando.cs
@@ -24,9 +24,8 @@ namespace Moonstorm.Starstorm2.Survivors
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
         public void ScepterCompat()
         {
-            //AncientScepter.AncientScepterItem.instance.RegisterScepterSkill(SS2Assets.LoadAsset<SkillDef>("NemmandoScepterSubmission"), "NemmandoBody", SkillSlot.Special, 0);
-            //AncientScepter.AncientScepterItem.instance.RegisterScepterSkill(SS2Assets.LoadAsset<SkillDef>("NemmandoScepterBossAttack"), "NemmandoBody", SkillSlot.Special, 1);
-            // sorry
+            AncientScepter.AncientScepterItem.instance.RegisterScepterSkill(SS2Assets.LoadAsset<SkillDef>("NemmandoScepterSubmission"), "NemmandoBody", SkillSlot.Special, 0);
+            AncientScepter.AncientScepterItem.instance.RegisterScepterSkill(SS2Assets.LoadAsset<SkillDef>("NemmandoScepterBossAttack"), "NemmandoBody", SkillSlot.Special, 1);
         }
 
         public override void ModifyPrefab()

--- a/SS2-Project/Assets/Starstorm2/Modules/Pickups/Items/Tier1/ArmedBackpack.cs
+++ b/SS2-Project/Assets/Starstorm2/Modules/Pickups/Items/Tier1/ArmedBackpack.cs
@@ -1,6 +1,9 @@
-﻿using RoR2;
+﻿using R2API;
+using RoR2;
 using RoR2.Items;
+using RoR2.Projectile;
 using System.Linq;
+using UnityEngine;
 
 namespace Moonstorm.Starstorm2.Items
 {
@@ -9,9 +12,9 @@ namespace Moonstorm.Starstorm2.Items
     {
         public override ItemDef ItemDef { get; } = SS2Assets.LoadAsset<ItemDef>("ArmedBackpack");
 
-        [ConfigurableField(ConfigDesc = "Damage dealt by the backpack's missle per stack. (1 = 100%)")]
+        [ConfigurableField(ConfigDesc = "Damage dealt by the missle per stack. (1 = 100%)")]
         [TokenModifier("SS2_ITEM_ARMEDBACKPACK_DESC", StatTypes.Percentage, 0)]
-        public static float backpackDamage = 1f;
+        public static float backpackDamageCoeff = 4f;
 
         [ConfigurableField(ConfigDesc = "Proc multiplier per percentage of health lost. (1 = 100% of health fraction lost)")]
         [TokenModifier("SS2_ITEM_ARMEDBACKPACK_DESC", StatTypes.Default,1)]
@@ -22,6 +25,7 @@ namespace Moonstorm.Starstorm2.Items
         public static float procMin = 15;
 
         public static ProcChainMask ignoredProcs;
+        public GameObject missilePrefab;
 
         public sealed class Behavior : BaseItemBodyBehavior, IOnTakeDamageServerReceiver
         {
@@ -36,10 +40,10 @@ namespace Moonstorm.Starstorm2.Items
                     var playerBody = damageReport.victimBody;
                     var rollChance = percentHPLoss > procMin ? percentHPLoss : procMin;
 
-                    SS2Log.Debug("chance was: " + rollChance);
+                    //SS2Log.Debug("chance was: " + rollChance);
                     if (Util.CheckRoll(rollChance, playerBody.master))
                     {
-                        float damageCoefficient = backpackDamage * stack;
+                        float damageCoefficient = backpackDamageCoeff * stack;
                         float missileDamage = playerBody.damage * damageCoefficient;
 
                         var teamIndex = damageReport.attackerTeamIndex;
@@ -49,6 +53,7 @@ namespace Moonstorm.Starstorm2.Items
                         {
                             attacker = null; //this prevents it from firing into blood shrines and i guess yourself/teammates if that lunar active is involved
                         }
+                        //var missleObject = GlobalEventManager.CommonAssets.missilePrefab;
                         MissileUtils.FireMissile(
                             playerBody.corePosition,
                             playerBody,
@@ -58,7 +63,7 @@ namespace Moonstorm.Starstorm2.Items
                             Util.CheckRoll(playerBody.crit, playerBody.master),
                             GlobalEventManager.CommonAssets.missilePrefab,
                             DamageColorIndex.Item,
-                            true);
+                            false);
                     }
                 }
             }

--- a/SS2-Project/Assets/Starstorm2/Modules/Pickups/Items/Tier1/X4.cs
+++ b/SS2-Project/Assets/Starstorm2/Modules/Pickups/Items/Tier1/X4.cs
@@ -85,10 +85,14 @@ namespace Moonstorm.Starstorm2.Items
                 orig(self, skill);
                 //skill == skill.characterBody.skillLocator.secondaryBonusStockSkill
                 //skill.skillFamily.ToString().Contains("Secondary")
-                if (skill == skill.characterBody.skillLocator.secondaryBonusStockSkill)
+                if (self.inventory)
                 {
-                    float amntToHeal = flatHealth + self.healthComponent.health * (percentHealth + (percentHealthStacking * (stack - 1)));
-                    self.healthComponent.Heal(amntToHeal, ignoredProcs, true);
+                    int count = self.inventory.GetItemCount(SS2Content.Items.X4); //again i could use stack here probably but i just wanna make sure this works we can fix it later
+                    if (skill == skill.characterBody.skillLocator.secondaryBonusStockSkill && count > 0)
+                    {
+                        float amntToHeal = flatHealth + self.healthComponent.health * (percentHealth + (percentHealthStacking * (count - 1)));
+                        self.healthComponent.Heal(amntToHeal, ignoredProcs, true);
+                    }
                 }
                 //SS2Log.Debug("print list!: family: " + skill.skillFamily + " |  _family: " + skill._skillFamily + " |  " + skill.skillOverrides);
                 //if(skill.skill

--- a/SS2-Project/Assets/Starstorm2/Modules/Pickups/Items/Tier1/X4.cs
+++ b/SS2-Project/Assets/Starstorm2/Modules/Pickups/Items/Tier1/X4.cs
@@ -87,7 +87,7 @@ namespace Moonstorm.Starstorm2.Items
                 //skill.skillFamily.ToString().Contains("Secondary")
                 if (self.inventory)
                 {
-                    int count = self.inventory.GetItemCount(SS2Content.Items.X4); //again i could use stack here probably but i just wanna make sure this works we can fix it later
+                    int count = self.inventory.GetItemCount(SS2Content.Items.X4.itemIndex); //again i could use stack here probably but i just wanna make sure this works we can fix it later
                     if (skill == skill.characterBody.skillLocator.secondaryBonusStockSkill && count > 0)
                     {
                         float amntToHeal = flatHealth + self.healthComponent.health * (percentHealth + (percentHealthStacking * (count - 1)));

--- a/SS2-Project/Assets/Starstorm2/README.md
+++ b/SS2-Project/Assets/Starstorm2/README.md
@@ -53,6 +53,14 @@ There are no issues. The mod is perfect.
 ## Changelog
 
 **Warning: content spoilers below!**
+### 0.3.39β
+* Minor Fixes/Adjustments.
+    * X4 no longer allows enemies to heal on using their secondary skills when they don't have it.
+    * Slightly reduced the height of Executioner's special. It's a bit more reasonable now.
+    * Buffed Armed Backpack's damage from 100% to 400%. It's an on damage proccing item that only hits one enemy, so it having a large payoff is justified.
+    * Actually properly adds Nemmando's Scepter skills. Executioner will come later!
+    * Prevents Blizzards from completely blinding you. The snow is lighter now.
+
 ### 0.3.38β
 * Updated to Survivors of the Void & MSU 1.0.1. 
     * This update has notable balance changes! Please delete your configs. 

--- a/SS2-Project/Assets/Starstorm2/SS2-Manifest.asset
+++ b/SS2-Project/Assets/Starstorm2/SS2-Manifest.asset
@@ -131,7 +131,7 @@ MonoBehaviour:
   Name: Starstorm2
   Description: A sequel of the RoR1 mod Starstorm, featuring new survivors, items,
     gameplay elements, and more. Updated for DLC1!
-  Version: 0.3.38
+  Version: 0.3.39
   Dependencies:
   - {fileID: 11400000, guid: 5ceb1d8ed3af40d4d806e9756b403649, type: 2}
 --- !u!114 &114431642618062350

--- a/SS2-Project/Assets/Starstorm2/Starstorm.cs
+++ b/SS2-Project/Assets/Starstorm2/Starstorm.cs
@@ -18,7 +18,7 @@ namespace Moonstorm.Starstorm2
     {
         internal const string guid = "com.TeamMoonstorm.Starstorm2-Nightly";
         internal const string modName = "Starstorm 2 Nightly";
-        internal const string version = "0.3.38";
+        internal const string version = "0.3.39";
 
         public static Starstorm instance;
         public static PluginInfo pluginInfo;


### PR DESCRIPTION
 * X4 no longer allows enemies to heal on using their secondary skills when they don't have it.
* Slightly reduced the height of Executioner's special. It's a bit more reasonable now.
* Buffed Armed Backpack's damage from 100% to 400%. It's an on damage proccing item that only hits one enemy, so it having a large payoff is justified.
* Actually properly adds Nemmando's Scepter skills. Executioner will come later! (Fixes #73)
* Prevents Blizzards from completely blinding you. The snow is lighter now.