### PR TITLE
Reduce Mimic spawn weight 

### DIFF
--- a/SS2-Project/Assets/Starstorm2/AssetStorm/Base/Characters/Monsters/Mimic/midcMimic.asset
+++ b/SS2-Project/Assets/Starstorm2/AssetStorm/Base/Characters/Monsters/Mimic/midcMimic.asset
@@ -26,7 +26,7 @@ MonoBehaviour:
         _asset: {fileID: 11400000, guid: 4d35c2f91855c854abd3573322147753, type: 2}
         _address: 
         _useDirectReference: 1
-      selectionWeight: 12
+      selectionWeight: 2
       spawnDistance: 0
       preventOverhead: 0
       minimumStageCompletions: 0


### PR DESCRIPTION
Reduces Mimic's spawn weight from 12 -> 2. They are now half as common as big chests. 