### PR TITLE
Update obsolete PickupDropTable.GenerateDrop calls that throw an error

### DIFF
--- a/SS2-Project/Assets/Starstorm2/Modules/EntityStates/Events/Weather/Storm.cs
+++ b/SS2-Project/Assets/Starstorm2/Modules/EntityStates/Events/Weather/Storm.cs
@@ -334,10 +334,14 @@ namespace EntityStates.Events
         {
             public void OnKilledServer(DamageReport damageReport)
             {
-                PickupIndex pickupIndex = StormController.dropTable.GenerateDrop(StormController.instance.treasureRng);
-                if (pickupIndex != PickupIndex.none)
+                UniquePickup pickup = StormController.dropTable.GeneratePickup(StormController.instance.treasureRng);
+                if (pickup.pickupIndex != PickupIndex.none)
                 {
-                    PickupDropletController.CreatePickupDroplet(pickupIndex, damageReport.victimBody.corePosition, Vector3.up * 20f);
+                    PickupDropletController.CreatePickupDroplet(new GenericPickupController.CreatePickupInfo
+                    {
+                        pickup = pickup,
+                    },
+                    damageReport.victimBody.corePosition, Vector3.up * 20f);
                 }
             }
         }

--- a/SS2-Project/Assets/Starstorm2/Modules/Pickups/Equipments/AffixEmpyrean.cs
+++ b/SS2-Project/Assets/Starstorm2/Modules/Pickups/Equipments/AffixEmpyrean.cs
@@ -234,10 +234,14 @@ namespace SS2.Equipments
                 if (numItems == 1) direction = Vector3.zero;
                 Vector3 velocity = Vector3.up * 20f + direction * 10f;
 
-                PickupIndex pickupIndex = RoR2.Artifacts.SacrificeArtifactManager.dropTable.GenerateDrop(RoR2.Artifacts.SacrificeArtifactManager.treasureRng);
-                if (pickupIndex != PickupIndex.none)
+                UniquePickup uniquePickup = RoR2.Artifacts.SacrificeArtifactManager.dropTable.GeneratePickup(RoR2.Artifacts.SacrificeArtifactManager.treasureRng);
+                if (uniquePickup.pickupIndex != PickupIndex.none)
                 {
-                    PickupDropletController.CreatePickupDroplet(pickupIndex, damageReport.victimBody.corePosition, velocity);
+                    PickupDropletController.CreatePickupDroplet(new GenericPickupController.CreatePickupInfo
+                    {
+                        pickup = uniquePickup
+                    },
+                    damageReport.victimBody.corePosition, velocity);
                 }
             }
 
@@ -252,7 +256,11 @@ namespace SS2.Equipments
 
                 if (pickupIndex != PickupIndex.none)
                 {
-                    PickupDropletController.CreatePickupDroplet(pickupIndex, damageReport.victimBody.corePosition, Vector3.up * 20f);
+                    PickupDropletController.CreatePickupDroplet(new GenericPickupController.CreatePickupInfo
+                    {
+                        pickup = new UniquePickup(pickupIndex)
+                    },
+                    damageReport.victimBody.corePosition, Vector3.up * 20f);
                 }
 
 

--- a/SS2-Project/Assets/Starstorm2/Modules/Pickups/Items/Curio/ItemOnBossKill.cs
+++ b/SS2-Project/Assets/Starstorm2/Modules/Pickups/Items/Curio/ItemOnBossKill.cs
@@ -27,16 +27,20 @@ namespace SS2.Items
             int bossItems = SS2Util.GetItemCountForPlayers(SS2Content.Items.ItemOnBossKill);
             if (bossItems > 0 && damageReport.victimIsChampion)
             {
-                PickupIndex pickupIndex = PickupIndex.none;
+                UniquePickup pickup = UniquePickup.none;
                 if (Util.CheckRoll(1 - Mathf.Pow(0.97f, bossItems) * 100f) && damageReport.victimBody.TryGetComponent(out DeathRewards deathRewards))
                 {
-                    pickupIndex = deathRewards.bossDropTable ? deathRewards.bossDropTable.GenerateDrop(dropRng) : (PickupIndex)deathRewards.bossPickup;
+                    pickup = deathRewards.bossDropTable ? deathRewards.bossDropTable.GeneratePickup(dropRng) : new UniquePickup((PickupIndex)deathRewards.bossPickup);
                 }
-                if (pickupIndex == PickupIndex.none)
-                    pickupIndex = dropTable.GenerateDrop(dropRng);
-                if (pickupIndex != PickupIndex.none)
+                if (pickup.pickupIndex == PickupIndex.none)
+                    pickup = dropTable.GeneratePickup(dropRng);
+                if (pickup.pickupIndex != PickupIndex.none)
                 {
-                    PickupDropletController.CreatePickupDroplet(pickupIndex, damageReport.victimBody.corePosition, Vector3.up * 20f);
+                    PickupDropletController.CreatePickupDroplet(new GenericPickupController.CreatePickupInfo
+                    {
+                        pickup = pickup,
+                    },
+                    damageReport.victimBody.corePosition, Vector3.up * 20f);
                 }
             }
         }

--- a/SS2-Project/Assets/Starstorm2/Modules/Pickups/Items/Curio/ItemOnEliteKill.cs
+++ b/SS2-Project/Assets/Starstorm2/Modules/Pickups/Items/Curio/ItemOnEliteKill.cs
@@ -26,10 +26,14 @@ namespace SS2.Items
             int eliteItems = SS2Util.GetItemCountForPlayers(SS2Content.Items.ItemOnEliteKill);
             if (eliteItems > 0 && damageReport.victimIsElite && Util.CheckRoll(6f + 2f * (eliteItems - 1))) // realizing i have no idea how to use run seeds/rng correctly
             {
-                PickupIndex pickupIndex = dropTable.GenerateDrop(dropRng);
-                if (pickupIndex != PickupIndex.none)
+                UniquePickup pickup = dropTable.GeneratePickup(dropRng);
+                if (pickup.pickupIndex != PickupIndex.none)
                 {
-                    PickupDropletController.CreatePickupDroplet(pickupIndex, damageReport.victimBody.corePosition, Vector3.up * 20f);
+                    PickupDropletController.CreatePickupDroplet(new GenericPickupController.CreatePickupInfo
+                    {
+                        pickup = pickup,
+                    },
+                    damageReport.victimBody.corePosition, Vector3.up * 20f);
                 }
             }
         }

--- a/SS2-Project/Assets/Starstorm2/Modules/Pickups/Items/Curio/ScrapFromChest.cs
+++ b/SS2-Project/Assets/Starstorm2/Modules/Pickups/Items/Curio/ScrapFromChest.cs
@@ -15,20 +15,20 @@ namespace SS2.Items
 
         public override void Initialize()
         {
-            On.RoR2.PurchaseInteraction.OnInteractionBegin += OnInteractionBegin;
+            PurchaseInteraction.onPurchaseGlobalServer += OnPurchaseGlobalServer;
         }
-        private void OnInteractionBegin(On.RoR2.PurchaseInteraction.orig_OnInteractionBegin orig, PurchaseInteraction self, Interactor activator)
+
+        private void OnPurchaseGlobalServer(CostTypeDef.PayCostContext payCostContext, CostTypeDef.PayCostResults _)
         {
-            orig(self, activator);
             int scrap = SS2Util.GetItemCountForPlayers(SS2Content.Items.ScrapFromChest);
-            if (self.TryGetComponent(out ChestBehavior chest))
+            if (payCostContext.purchasedObject.TryGetComponent<ChestBehavior>(out var chest))
             {
                 if (scrap > 0 && Util.CheckRoll(33f + 11 * (scrap - 1)))
                 {
-                    PickupIndex pickup = chest.dropTable.GenerateDrop(chest.rng);
-                    if (pickup != PickupIndex.none)
+                    UniquePickup pickup = chest.dropTable.GeneratePickup(chest.rng);
+                    if (pickup.pickupIndex != PickupIndex.none)
                     {
-                        PickupIndex scrapIndex = PickupCatalog.FindScrapIndexForItemTier(PickupCatalog.GetPickupDef(pickup).itemTier);
+                        PickupIndex scrapIndex = PickupCatalog.FindScrapIndexForItemTier(PickupCatalog.GetPickupDef(pickup.pickupIndex).itemTier);
                         if (scrapIndex != PickupIndex.none)
                         {
                             //
@@ -39,9 +39,7 @@ namespace SS2.Items
                         }
                     }
                 }
-
             }
         }
-
     }
 }

--- a/SS2-Project/Assets/Starstorm2/Modules/Pickups/Items/Lunar/RelicOfTermination.cs
+++ b/SS2-Project/Assets/Starstorm2/Modules/Pickups/Items/Lunar/RelicOfTermination.cs
@@ -218,7 +218,11 @@ namespace SS2.Items
                         var deathRewards = ((obj.victimBody != null) ? obj.victimBody.GetComponent<DeathRewards>() : null);
                         if (deathRewards)
                         {
-                            PickupDropletController.CreatePickupDroplet(deathRewards.bossDropTable.GenerateDrop(terminationRNG), obj.victim.transform.position, vector);
+                            PickupDropletController.CreatePickupDroplet(new GenericPickupController.CreatePickupInfo
+                            {
+                                pickup = deathRewards.bossDropTable.GeneratePickup(terminationRNG),
+                            },
+                            obj.victim.transform.position, vector);
                         }
                         else
                         {
@@ -231,7 +235,11 @@ namespace SS2.Items
                                 }
                             }
                             Util.ShuffleList<PickupIndex>(bossOptions);
-                            PickupDropletController.CreatePickupDroplet(bossOptions[0], obj.victim.transform.position, vector);
+                            PickupDropletController.CreatePickupDroplet(new GenericPickupController.CreatePickupInfo
+                            {
+                                pickup = new UniquePickup(bossOptions[0]),
+                            },
+                            obj.victim.transform.position, vector);
                         }
 
                     }


### PR DESCRIPTION
While the methods called internally by GenerateDrop have been left in the code for backwards compatibility, they raise a NotImplementedException, so this method needs to be avoided.

Closes #945

Not really urgent, but the compilation log lists quite a few obsolete method/field warnings, though they're mainly inventory related and they're harmless because they're backwards compatible. It wouldn't hurt to update them to make those warnings go away, as well as any related to unused code or hiding inherited members.